### PR TITLE
Fix installation warnings about unmet dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,8 +25,8 @@
   },
   "dependencies": {
     "yeoman-generator": "^0.18.0",
-    "chalk": "^0.5.0",
-    "yosay": "^0.3.0",
+    "chalk": "^1.0.0",
+    "yosay": "^1.0.0",
     "yo": ">=1.0.0"
   }
 }


### PR DESCRIPTION
Hi,
This commit bumps version of two NPM modules that core
generator module depends on to minimal version required as
dependency

Without this updates one could not be able to install and develop locally the generator. For example on my machine it failed with following problems:
```
npm WARN unmet dependency /Users/piotrblazejewicz/git/generator-code/node_modules/yeoman-generator requires chalk@'^1.0.0' but will load
npm WARN unmet dependency /Users/piotrblazejewicz/git/generator-code/node_modules/chalk,
npm WARN unmet dependency which is version 0.5.1
npm WARN unmet dependency /Users/piotrblazejewicz/git/generator-code/node_modules/yosay requires chalk@'^0.4.0' but will load
npm WARN unmet dependency /Users/piotrblazejewicz/git/generator-code/node_modules/chalk,
npm WARN unmet dependency which is version 0.5.1
npm WARN unmet dependency /Users/piotrblazejewicz/git/generator-code/node_modules/yo requires chalk@'^1.0.0' but will load
npm WARN unmet dependency /Users/piotrblazejewicz/git/generator-code/node_modules/chalk,
npm WARN unmet dependency which is version 0.5.1
npm WARN unmet dependency /Users/piotrblazejewicz/git/generator-code/node_modules/yo requires yosay@'^1.0.0' but will load
npm WARN unmet dependency /Users/piotrblazejewicz/git/generator-code/node_modules/yosay,
npm WARN unmet dependency which is version 0.3.0
```
The npm states *WARN* but actual NPM link failed to install generator. Only after this bumps I was able to link generator correctly locally - so I think it will also fix possible problems for users who use generator via `npm install -g` option.
The change should be transparent to users by the way.

https://www.npmjs.com/package/chalk
https://www.npmjs.com/package/yosay

Thanks!

